### PR TITLE
Updated Upstream (Paper) 1.16.5

### DIFF
--- a/patches/server/0073-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0073-Replace-player-chunk-loader-system.patch
@@ -1795,10 +1795,10 @@ index ff3c84fb6f398e68cf9421dd9f8f22e7af74c970..fddf35e6fa91f8eb838979b66c7e8ea2
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cfe6898dc373fe55a08acf5c90e200061aa7d0fc..ed1bb89ae7b85bf4017315d6189d6cbf595aefe5 100644
+index c845896764cfa29f5d111c674b1a9081bd4993a7..f28f973452ec3eb2d09d0dc1e27e8bb5a04216c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2265,15 +2265,70 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2266,15 +2266,70 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  


### PR DESCRIPTION
Backport changes from Paper 1.16.5 to bring Tuinity 1.16 on par with upstream.

Upstream has released updates that appears to apply and compile correctly

Paper Changes:
06b0b573d Fix NPE for msg send on player join (#6041)