### PR TITLE
Link to 1.17 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## How To (Server Admins)
 Tuinity uses the same paperclip jar system that Paper uses.
 
-You can download the latest build of Tuinity by going [here](https://ci.codemc.io/job/Spottedleaf/job/Tuinity/).
+You can download the latest build of Tuinity by going [here](https://ci.codemc.io/job/Spottedleaf/job/Tuinity-1.17/).
 
 You can also [build it yourself](https://github.com/Tuinity/Tuinity#building).
 


### PR DESCRIPTION
I accidentally downloaded the wrong version and almost broke my server. It's very confusing that the master branch is updated to 1.17, but not the download link.