### PR TITLE
Fix spelling of optimise

### DIFF
--- a/patches/server/0052-Optimise-map-impl-for-tracked-players.patch
+++ b/patches/server/0052-Optimise-map-impl-for-tracked-players.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Fri, 19 Feb 2021 22:51:52 -0800
-Subject: [PATCH] Oprimise map impl for tracked players
+Subject: [PATCH] Optimise map impl for tracked players
 
 Reference2BooleanOpenHashMap is going to have
 better lookups than HashMap.


### PR DESCRIPTION
Patch 52 "Oprimise map impl for tracked players" misspells optimise as oprimise